### PR TITLE
support for multidate

### DIFF
--- a/autoform-bs-datepicker.js
+++ b/autoform-bs-datepicker.js
@@ -77,16 +77,6 @@ Template.afBootstrapDatepicker.rendered = function () {
         $input.datepicker('update', data.value);
       }
     }
-    
-    var valArray = this.datepicker('getUTCDates');
-      var allAreDates = _.filter(valArray, function(val){ return val instanceof Date; });
-      
-        if (valArray.length === allAreDates.length) {
-          return valArray;
-        }
-        else {
-          return val;
-        }
 
     // set start date if there's a min in the schema
     if (data.min instanceof Date) {

--- a/autoform-bs-datepicker.js
+++ b/autoform-bs-datepicker.js
@@ -68,6 +68,25 @@ Template.afBootstrapDatepicker.rendered = function () {
     } else if (typeof data.value === "string") {
       $input.datepicker('update', data.value);
     }
+    
+    if (_.isArray(data.value)) {
+      var allAreDates = _.filter(data.value, function(val){ return val instanceof Date; });
+      if (data.value.length === allAreDates.length) {
+          $input.datepicker('setUTCDates', data.value);
+      } else {
+        $input.datepicker('update', data.value);
+      }
+    }
+    
+    var valArray = this.datepicker('getUTCDates');
+      var allAreDates = _.filter(valArray, function(val){ return val instanceof Date; });
+      
+        if (valArray.length === allAreDates.length) {
+          return valArray;
+        }
+        else {
+          return val;
+        }
 
     // set start date if there's a min in the schema
     if (data.min instanceof Date) {

--- a/autoform-bs-datepicker.js
+++ b/autoform-bs-datepicker.js
@@ -28,10 +28,15 @@ AutoForm.addInputType("bootstrap-datepicker", {
       return val;
     },
     "dateArray": function (val) {
-      if (val instanceof Date) {
-        return [val];
-      }
-      return val;
+      var valArray = this.datepicker('getUTCDates');
+      var allAreDates = _.filter(valArray, function(val){ return val instanceof Date; });
+      
+        if (valArray.length === allAreDates.length) {
+          return valArray;
+        }
+        else {
+          return val;
+        }
     }
   }
 });


### PR DESCRIPTION
In the previous plugin version If a schema field had `type:[Date]` and in `datePickerOptions` multiple dates were enabled `multidate: true` - only the first date was saved into array after form submit.

Example:
1. I choose 2 dates in datepicker: `07/03/2015,10/04/2015`
2. I submit the form
3. there is only one value in dates array: 2015-03-07 00:00:00.000Z

Also the problem was with update form: in rendered template nothing appeared in datepicker input field if we had `type:[Date]`.

With new changes it is solved.
