### PR TITLE
Return an empty string instead of undefined when the field is empty

### DIFF
--- a/autoform-bs-datepicker.js
+++ b/autoform-bs-datepicker.js
@@ -3,10 +3,11 @@
 AutoForm.addInputType("bootstrap-datepicker", {
   template: "afBootstrapDatepicker",
   valueOut: function () {
+    var val;
     if (this.val()) {
-      var val = this.datepicker('getUTCDate');
-      return (val instanceof Date) ? val : this.val();
+      val = this.datepicker('getUTCDate');
     }
+    return (val instanceof Date) ? val : this.val();
   },
   valueConverters: {
     "string": function (val) {


### PR DESCRIPTION
Fix #24
